### PR TITLE
Add SBOM generation workflow

### DIFF
--- a/.github/workflows/create_sbom.yml
+++ b/.github/workflows/create_sbom.yml
@@ -1,0 +1,42 @@
+name: Create SBOM
+run-name: create-sbom
+
+on:
+  push:
+    branches: [challenge]
+
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    name: Generate SBOM with cdxgen
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Java
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "24"
+
+      - name: Install cdxgen
+        run: npm install -g @cyclonedx/cdxgen@12.1.3
+
+      - name: Generate SBOM
+        run: cdxgen -o sbom.json --spec-version 1.5
+
+      - name: Upload SBOM as artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: sbom
+          path: sbom.json


### PR DESCRIPTION
## Summary
- Adds CycloneDX SBOM generation via cdxgen (v12.1.3), triggered on push to challenge
- SBOM is generated in CycloneDX JSON v1.5 format
- SBOM is uploaded as a GitHub Actions artifact

## Test plan
- [ ] Verify workflow runs on push to challenge
- [ ] Check that `sbom.json` artifact is produced